### PR TITLE
Rounded corners added

### DIFF
--- a/src/Window.vala
+++ b/src/Window.vala
@@ -48,6 +48,9 @@ namespace App {
                 Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
             );
 
+            //style window for rounded corners
+            get_style_context ().add_class("rounded");
+
             // Save the window's position on close
             delete_event.connect (() => {
                 int root_x, root_y;


### PR DESCRIPTION
Hi @fleury08 I've noticed that you ported this app to eOS 6. Good work!
When I was using it I noticed that it doesn't use rounded corners (which feels quite odd in Odin) so I decided to open this pull request to add them. Originally I wanted to make use of `Hdy.Window` but when I started looking at your code I realized I would had to make some big changes to your code base in order to achieve those rounded corners. However I remembered a trick; If you add a custom headerbar to a window (this app already had a custom headerbar) and you add the `"rounded"` CSS class to the window, it will have rounded corners (at least in Odin).
This  is the exact same trick I've used in [Hasher](https://github.com/JeysonFlores/hasher) and [ElementaryCpp](https://github.com/JeysonFlores/ElementaryCpp).
Here's the result:
![image](https://user-images.githubusercontent.com/68255757/135485890-6d01a69e-4b20-4d3f-9230-06ef0546a829.png)

Thanks for reading!